### PR TITLE
allow deployment to leverage chart values replicas

### DIFF
--- a/chart/gateway/templates/deployment.yaml
+++ b/chart/gateway/templates/deployment.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.replicas }}
   strategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
replicas was already established in values.yaml but wasn't bound to deployment.yaml