### PR TITLE
CORE-6772: Move Gateway Tests of Old GKE Cluster

### DIFF
--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -94,6 +94,9 @@ jobs:
       - name: "Install mpdev from Docker"
         run: |
           echo "Installing mpdev from Docker image..."
+
+          gcloud auth configure-docker gcr.io
+
           docker pull gcr.io/cloud-marketplace-tools/k8s/dev:latest
           docker create --name mpdev-tmp gcr.io/cloud-marketplace-tools/k8s/dev:latest
           docker cp mpdev-tmp:/scripts/dev/mpdev .
@@ -103,7 +106,7 @@ jobs:
           sudo mv mpdev /usr/local/bin/
 
           echo "Installed mpdev version:"
-          mpdev version || echo "Failed to execute mpdev"
+          mpdev version
 
       - name: "Check mpdev release page"
         if: ${{ failure() }}

--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -91,21 +91,19 @@ jobs:
         with:
           version: 'v3.11.1'
 
-      - name: "Install mpdev"
+      - name: "Install mpdev from Docker"
         run: |
-          echo "Downloading mpdev v0.11.8..."
-          curl -L -v -o mpdev.tar.gz https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/releases/download/v0.11.8/mpdev_linux_amd64.tar.gz
+          echo "Installing mpdev from Docker image..."
+          docker pull gcr.io/cloud-marketplace-tools/k8s/dev:latest
+          docker create --name mpdev-tmp gcr.io/cloud-marketplace-tools/k8s/dev:latest
+          docker cp mpdev-tmp:/scripts/dev/mpdev .
+          docker rm mpdev-tmp
 
-          echo "Checking downloaded file:"
-          ls -la mpdev.tar.gz
-          file mpdev.tar.gz
+          chmod +x mpdev
+          sudo mv mpdev /usr/local/bin/
 
-          echo "Attempting to extract file:"
-          tar -xzvf mpdev.tar.gz
-
-          chmod +x mpdev 2>/dev/null || echo "Could not chmod mpdev (file likely doesn't exist)"
-          sudo mv mpdev /usr/local/bin/ 2>/dev/null || echo "Could not move mpdev (file likely doesn't exist)"
-          mpdev version 2>/dev/null || echo "mpdev command not available"
+          echo "Installed mpdev version:"
+          mpdev version || echo "Failed to execute mpdev"
 
       - name: "Check mpdev release page"
         if: ${{ failure() }}

--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -1,0 +1,184 @@
+name: 🚀 Deploy Gateway to Dev GKE
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: 'Namespace for deployment'
+        required: true
+        default: 'virtru'
+      gateway_hostname:
+        description: 'Gateway hostname'
+        required: true
+        default: 'gateway-development.virtru.com'
+      primary_mailing_domain:
+        description: 'Primary mailing domain'
+        required: true
+        default: 'virtru.example.com'
+      number_of_licenses:
+        description: 'Number of licenses'
+        required: true
+        default: '10'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy-gateway:
+    runs-on: virtru-scale-set-runner
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+
+      - name: "Authenticate to Google Cloud"
+        id: "gcp-auth"
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.5
+        with:
+          workload_identity_provider: 'projects/1053957112592/locations/global/workloadIdentityPools/github-actions-oidc-pool/providers/github-actions-oidc-provider'
+          service_account: 'github-actions-sa@prj-infra-automation-ktbz.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      - name: 'Set up Cloud SDK'
+        id: setup-gcloud
+        uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
+        with:
+          version: '>= 363.0.0'
+          install_components: 'kubectl'
+
+      - name: "Setup Helm"
+        uses: azure/setup-helm@1e6d3aaf479f04f23407416f5f3a9f6701254b98 # v3.11.1
+        with:
+          version: 'v3.11.1'
+
+      - name: "Install mpdev"
+        run: |
+          curl -L -o mpdev.tar.gz https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/releases/download/v0.11.8/mpdev_linux_amd64.tar.gz
+          tar -xzvf mpdev.tar.gz
+          chmod +x mpdev
+          sudo mv mpdev /usr/local/bin/
+          mpdev version
+
+      - name: "Docker login to Artifact Registry"
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: "Connect to Dev GKE Cluster"
+        uses: google-github-actions/get-gke-credentials@4d042ce21867b02551fee51e20bffc05689d8f94
+        with:
+          cluster_name: hg-dev-green
+
+      - name: "Update Helm dependencies"
+        run: |
+          cd chart/gateway
+          helm dependency update
+          cd -
+
+      - name: "Set version and registry variables"
+        run: |
+          VERSION=$(cat VERSION)
+          echo "TAG=${VERSION}" >> $GITHUB_ENV
+          echo "DEPLOYER_VERSION=$(echo ${VERSION} | cut -d'.' -f 1-2)" >> $GITHUB_ENV
+          echo "REGISTRY=us-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway" >> $GITHUB_ENV
+          
+          echo "::notice::Deploying to DEVELOPMENT environment"
+
+      - name: "Install Application CRD"
+        run: |
+          kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
+
+      - name: "Build deployer image"
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
+        with:
+          context: .
+          file: dev.Dockerfile
+          push: true
+          build-args: |
+            TAG=${{ env.TAG }}
+            REGISTRY=${{ env.REGISTRY }}
+          tags: ${{ env.REGISTRY }}/deployer:${{ env.DEPLOYER_VERSION }}
+          platforms: linux/amd64
+
+      - name: "Verify deployer image in registry"
+        run: |
+          echo "Verifying image presence in registry..."
+          sleep 5 # Small delay to ensure image visibility
+          
+          if gcloud artifacts docker images describe "${{ env.REGISTRY }}/deployer:${{ env.DEPLOYER_VERSION }}"; then
+            echo "✅ Image successfully published and available in Artifact Registry"
+          else
+            echo "⚠️ Image not found in Artifact Registry after pushing."
+          fi
+
+      - name: "Create deployment parameters"
+        run: |
+          cat > deploy_parameters.json << EOF
+          {
+            "name": "gateway",
+            "namespace": "${{ github.event.inputs.namespace }}",
+            "gatewayHostname": "${{ github.event.inputs.gateway_hostname }}",
+            "gatewayApiTokenName": "token",
+            "gatewayApiSecret": "mysecret",
+            "gatewayFlow": "Outbound - Data Loss Prevention",
+            "primaryMailingDomain": "${{ github.event.inputs.primary_mailing_domain }}",
+            "amplitudeToken": "fake-token",
+            "pricingPlan": "gateway___gmail_encryption__per_user_per_day_",
+            "numberOfLicenses": "${{ github.event.inputs.number_of_licenses }}",
+            "reportingSecret": "gs://cloud-marketplace-tools/reporting_secrets/fake_reporting_secret.yaml",
+            "cse.appSecrets.hmac.tokenId": "my-hmac-token-id",
+            "cse.appSecrets.hmac.tokenSecret": "my-hmac-token-secret",
+            "cse.appSecrets.secretKey": "my-cse-secret-key",
+            "cse.appSecrets.ssl.certificate": "my-base64-ssl-certificate",
+            "cse.appSecrets.ssl.privateKey": "my-base64-ssl-private-key",
+            "cse.appConfig.jwksAuthzIssuers": "eyAidmlydHJ1LXRlc3QiOiAiaHR0cDovL2p3dC5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsL2p3ay5qc29uIiB9Cg==",
+            "cse.appConfig.jwksAuthnIssuers": "eyAidmlydHJ1LXRlc3QiOiAiaHR0cDovL2p3dC5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsL2p3ay5qc29uIiB9Cg==",
+            "cse.appConfig.jwtAud": "eyJhdXRobiI6InZpcnRydS10ZXN0IiwiYXV0aHoiOiJ2aXJ0cnUtdGVzdCJ9Cg==",
+            "cse.appConfig.jwtKaclsUrl": "http://cse.virtru.svc.cluster.local",
+            "cse.ingress.host": "cse.virtru.svc.cluster.local"
+          }
+          EOF
+          
+          echo "Deployment parameters:"
+          cat deploy_parameters.json
+
+      - name: "Create namespace if needed"
+        run: |
+          if ! kubectl get namespace ${{ github.event.inputs.namespace }} > /dev/null 2>&1; then
+            echo "Creating namespace ${{ github.event.inputs.namespace }}..."
+            kubectl create namespace ${{ github.event.inputs.namespace }}
+          else
+            echo "Namespace ${{ github.event.inputs.namespace }} already exists"
+          fi
+
+      - name: "Deploy with mpdev"
+        id: deploy
+        run: |
+          echo "Deploying Gateway to dev environment using mpdev..."
+          mpdev install --deployer="${REGISTRY}/deployer:${DEPLOYER_VERSION}" --parameters="$(cat deploy_parameters.json)"
+          echo "✅ Gateway deployment to dev completed successfully"
+
+      - name: "Verify deployment"
+        run: |
+          echo "Checking deployment status..."
+          
+          # Check for Application existence
+          if kubectl get application gateway -n ${{ github.event.inputs.namespace }}; then
+            echo "✅ Application 'gateway' created successfully"
+          
+            # Check pod status
+            echo "Pod status:"
+            kubectl get pods -n ${{ github.event.inputs.namespace }} -l app.kubernetes.io/name=gateway
+          
+            # Check other resources
+            echo "Deployment status:"
+            kubectl get all -n ${{ github.event.inputs.namespace }} -l app.kubernetes.io/name=gateway
+          else
+            echo "❌ Application 'gateway' not found in namespace '${{ github.event.inputs.namespace }}'."
+            exit 1
+          fi

--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -93,11 +93,25 @@ jobs:
 
       - name: "Install mpdev"
         run: |
-          curl -L -o mpdev.tar.gz https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/releases/download/v0.11.8/mpdev_linux_amd64.tar.gz
+          echo "Downloading mpdev v0.11.8..."
+          curl -L -v -o mpdev.tar.gz https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/releases/download/v0.11.8/mpdev_linux_amd64.tar.gz
+
+          echo "Checking downloaded file:"
+          ls -la mpdev.tar.gz
+          file mpdev.tar.gz
+
+          echo "Attempting to extract file:"
           tar -xzvf mpdev.tar.gz
-          chmod +x mpdev
-          sudo mv mpdev /usr/local/bin/
-          mpdev version
+
+          chmod +x mpdev 2>/dev/null || echo "Could not chmod mpdev (file likely doesn't exist)"
+          sudo mv mpdev /usr/local/bin/ 2>/dev/null || echo "Could not move mpdev (file likely doesn't exist)"
+          mpdev version 2>/dev/null || echo "mpdev command not available"
+
+      - name: "Check mpdev release page"
+        if: ${{ failure() }}
+        run: |
+          echo "Checking available releases of mpdev..."
+          curl -s https://api.github.com/repos/GoogleCloudPlatform/marketplace-k8s-app-tools/releases | jq -r '.[].tag_name'
 
       - name: "Docker login to Artifact Registry"
         uses: docker/login-action@v3

--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -21,6 +21,33 @@ on:
         default: '10'
   repository_dispatch:
     types: [ deploy-gateway ]
+  workflow_call:
+    inputs:
+      namespace:
+        description: 'Namespace for deployment'
+        type: string
+        default: 'virtru'
+        required: false
+      gateway_hostname:
+        description: 'Gateway hostname'
+        type: string
+        default: 'gateway-development.virtru.com'
+        required: false
+      primary_mailing_domain:
+        description: 'Primary mailing domain'
+        type: string
+        default: 'virtru.example.com'
+        required: false
+      number_of_licenses:
+        description: 'Number of licenses'
+        type: string
+        default: '10'
+        required: false
+      branch:
+        description: 'Branch to checkout'
+        type: string
+        default: ''
+        required: false
 
 permissions:
   contents: read
@@ -30,11 +57,12 @@ jobs:
   deploy-gateway:
     runs-on: virtru-scale-set-runner
     env:
-      BRANCH: ${{ github.event.client_payload.branch || github.ref_name }}
-      NAMESPACE: ${{ github.event.client_payload.namespace || github.event.inputs.namespace }}
-      GATEWAY_HOSTNAME: ${{ github.event.client_payload.gateway_hostname || github.event.inputs.gateway_hostname }}
-      PRIMARY_MAILING_DOMAIN: ${{ github.event.client_payload.primary_mailing_domain || github.event.inputs.primary_mailing_domain }}
-      NUMBER_OF_LICENSES: ${{ github.event.client_payload.number_of_licenses || github.event.inputs.number_of_licenses }}
+      BRANCH: ${{ inputs.branch || github.event.client_payload.branch || github.ref_name }}
+      NAMESPACE: ${{ inputs.namespace || github.event.client_payload.namespace || github.event.inputs.namespace }}
+      GATEWAY_HOSTNAME: ${{ inputs.gateway_hostname || github.event.client_payload.gateway_hostname || github.event.inputs.gateway_hostname }}
+      PRIMARY_MAILING_DOMAIN: ${{ inputs.primary_mailing_domain || github.event.client_payload.primary_mailing_domain || github.event.inputs.primary_mailing_domain }}
+      NUMBER_OF_LICENSES: ${{ inputs.number_of_licenses || github.event.client_payload.number_of_licenses || github.event.inputs.number_of_licenses }}
+
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -19,6 +19,8 @@ on:
         description: 'Number of licenses'
         required: true
         default: '10'
+  repository_dispatch:
+    types: [ deploy-gateway ]
 
 permissions:
   contents: read
@@ -27,11 +29,18 @@ permissions:
 jobs:
   deploy-gateway:
     runs-on: virtru-scale-set-runner
+    env:
+      BRANCH: ${{ github.event.client_payload.branch || github.ref_name }}
+      NAMESPACE: ${{ github.event.client_payload.namespace || github.event.inputs.namespace }}
+      GATEWAY_HOSTNAME: ${{ github.event.client_payload.gateway_hostname || github.event.inputs.gateway_hostname }}
+      PRIMARY_MAILING_DOMAIN: ${{ github.event.client_payload.primary_mailing_domain || github.event.inputs.primary_mailing_domain }}
+      NUMBER_OF_LICENSES: ${{ github.event.client_payload.number_of_licenses || github.event.inputs.number_of_licenses }}
 
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
+          ref: ${{ env.BRANCH }}
           persist-credentials: false
 
       - name: "Authenticate to Google Cloud"
@@ -121,15 +130,15 @@ jobs:
           cat > deploy_parameters.json << EOF
           {
             "name": "gateway",
-            "namespace": "${{ github.event.inputs.namespace }}",
-            "gatewayHostname": "${{ github.event.inputs.gateway_hostname }}",
+            "namespace": "${{ env.NAMESPACE }}",
+            "gatewayHostname": "${{ env.GATEWAY_HOSTNAME }}",
             "gatewayApiTokenName": "token",
             "gatewayApiSecret": "mysecret",
             "gatewayFlow": "Outbound - Data Loss Prevention",
-            "primaryMailingDomain": "${{ github.event.inputs.primary_mailing_domain }}",
+            "primaryMailingDomain": "${{ env.PRIMARY_MAILING_DOMAIN }}",
             "amplitudeToken": "fake-token",
             "pricingPlan": "gateway___gmail_encryption__per_user_per_day_",
-            "numberOfLicenses": "${{ github.event.inputs.number_of_licenses }}",
+            "numberOfLicenses": "${{ env.NUMBER_OF_LICENSES }}",
             "reportingSecret": "gs://cloud-marketplace-tools/reporting_secrets/fake_reporting_secret.yaml",
             "cse.appSecrets.hmac.tokenId": "my-hmac-token-id",
             "cse.appSecrets.hmac.tokenSecret": "my-hmac-token-secret",
@@ -168,17 +177,15 @@ jobs:
           echo "Checking deployment status..."
           
           # Check for Application existence
-          if kubectl get application gateway -n ${{ github.event.inputs.namespace }}; then
+          if kubectl get application gateway -n ${{ env.NAMESPACE }}; then
             echo "✅ Application 'gateway' created successfully"
-          
-            # Check pod status
+    
             echo "Pod status:"
-            kubectl get pods -n ${{ github.event.inputs.namespace }} -l app.kubernetes.io/name=gateway
-          
-            # Check other resources
+            kubectl get pods -n ${{ env.NAMESPACE }} -l app.kubernetes.io/name=gateway
+
             echo "Deployment status:"
-            kubectl get all -n ${{ github.event.inputs.namespace }} -l app.kubernetes.io/name=gateway
+            kubectl get all -n ${{ env.NAMESPACE }} -l app.kubernetes.io/name=gateway
           else
-            echo "❌ Application 'gateway' not found in namespace '${{ github.event.inputs.namespace }}'."
+            echo "❌ Application 'gateway' not found in namespace '${{ env.NAMESPACE }}'."
             exit 1
           fi

--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -66,14 +66,14 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH }}
           persist-credentials: false
 
       - name: "Authenticate to Google Cloud"
         id: "gcp-auth"
-        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.5
+        uses: google-github-actions/auth@v2 # v2.1.5
         with:
           workload_identity_provider: 'projects/1053957112592/locations/global/workloadIdentityPools/github-actions-oidc-pool/providers/github-actions-oidc-provider'
           service_account: 'github-actions-sa@prj-infra-automation-ktbz.iam.gserviceaccount.com'
@@ -81,13 +81,13 @@ jobs:
 
       - name: 'Set up Cloud SDK'
         id: setup-gcloud
-        uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
+        uses: google-github-actions/setup-gcloud@v2 # v2.1.1
         with:
           version: '>= 363.0.0'
           install_components: 'kubectl'
 
       - name: "Setup Helm"
-        uses: azure/setup-helm@1e6d3aaf479f04f23407416f5f3a9f6701254b98 # v3.11.1
+        uses: azure/setup-helm@v3
         with:
           version: 'v3.11.1'
 
@@ -100,14 +100,14 @@ jobs:
           mpdev version
 
       - name: "Docker login to Artifact Registry"
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@v3
         with:
           registry: us-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: "Connect to Dev GKE Cluster"
-        uses: google-github-actions/get-gke-credentials@4d042ce21867b02551fee51e20bffc05689d8f94
+        uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: hg-dev-green
 
@@ -131,7 +131,7 @@ jobs:
           kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
 
       - name: "Build deployer image"
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: dev.Dockerfile

--- a/.github/workflows/gke-deploy.yaml
+++ b/.github/workflows/gke-deploy.yaml
@@ -91,21 +91,31 @@ jobs:
         with:
           version: 'v3.11.1'
 
-      - name: "Install mpdev from Docker"
+      - name: "Install mpdev"
         run: |
-          echo "Installing mpdev from Docker image..."
+          echo "Installing mpdev..."
 
-          gcloud auth configure-docker gcr.io
+          kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
+          gcloud auth configure-docker --quiet
 
-          docker pull gcr.io/cloud-marketplace-tools/k8s/dev:latest
-          docker create --name mpdev-tmp gcr.io/cloud-marketplace-tools/k8s/dev:latest
-          docker cp mpdev-tmp:/scripts/dev/mpdev .
-          docker rm mpdev-tmp
+          echo "Pulling cloud-marketplace-tools Docker image..."
+          docker pull gcr.io/cloud-marketplace-tools/k8s/dev
 
-          chmod +x mpdev
-          sudo mv mpdev /usr/local/bin/
+          mkdir -p $HOME/bin
 
-          echo "Installed mpdev version:"
+          BIN_FILE="$HOME/bin/mpdev"
+          echo "Extracting mpdev script to $BIN_FILE"
+          docker run \
+            gcr.io/cloud-marketplace-tools/k8s/dev \
+            cat /scripts/dev > "$BIN_FILE"
+          chmod +x "$BIN_FILE"
+
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+          echo "Testing mpdev installation:"
+          $BIN_FILE --help
+
+          sudo cp "$BIN_FILE" /usr/local/bin/
           mpdev version
 
       - name: "Check mpdev release page"

--- a/.github/workflows/gke-verify.yaml
+++ b/.github/workflows/gke-verify.yaml
@@ -1,0 +1,98 @@
+name: Verify Gateway Marketplace Deployment on dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'chart/**'
+      - 'schema.yaml'
+      - 'dev.Dockerfile'
+      - 'VERSION'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify-marketplace:
+    runs-on: virtru-scale-set-runner
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+
+      - name: "Authenticate to Google Cloud"
+        id: "gcp-auth"
+        uses: google-github-actions/auth@62cf5bd3e4211a0a0b51f2c6d6a37129d828611d # v2.1.5
+        with:
+          workload_identity_provider: "projects/1053957112592/locations/global/workloadIdentityPools/github-actions-oidc-pool/providers/github-actions-oidc-provider"
+          service_account: "github-actions-sa@prj-infra-automation-ktbz.iam.gserviceaccount.com"
+          token_format: "access_token"
+
+      - name: "Setup gcloud CLI"
+        uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7
+        with:
+          install_components: 'kubectl'
+
+      - name: "Docker login to Artifact Registry"
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: "Connect to GKE Cluster"
+        uses: google-github-actions/get-gke-credentials@4d042ce21867b02551fee51e20bffc05689d8f94
+        with:
+          cluster_name: hg-dev-green
+
+      - name: "Install mpdev"
+        run: |
+          curl -L -o mpdev.tar.gz https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/releases/download/v0.11.8/mpdev_linux_amd64.tar.gz
+          tar -xzvf mpdev.tar.gz
+          chmod +x mpdev
+          sudo mv mpdev /usr/local/bin/
+
+      - name: "Update Helm dependencies"
+        run: |
+          cd chart/gateway
+          helm dependency update
+          cd -
+
+      - name: "Set version variables"
+        run: |
+          VERSION=$(cat VERSION)
+          echo "TAG=${VERSION}" >> $GITHUB_ENV
+          echo "DEPLOYER_VERSION=$(echo ${VERSION} | cut -d'.' -f 1-2)" >> $GITHUB_ENV
+          echo "REGISTRY=us-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway" >> $GITHUB_ENV
+
+      - name: "Build deployer image"
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v4.6.0
+        with:
+          context: .
+          file: dev.Dockerfile
+          push: true
+          build-args: |
+            TAG=${{ env.TAG }}
+            REGISTRY=${{ env.REGISTRY }}
+          tags: ${{ env.REGISTRY }}/deployer:${{ env.DEPLOYER_VERSION }}
+          platforms: linux/amd64
+
+      - name: "Install Application CRD"
+        run: |
+          kubectl apply -f "https://raw.githubusercontent.com/GoogleCloudPlatform/marketplace-k8s-app-tools/master/crd/app-crd.yaml"
+
+      - name: "Run marketplace verification"
+        run: |
+          export MPDEV_VERIFY_TIMEOUT=600 # 10 minutes
+
+          mpdev verify --deployer="${REGISTRY}/deployer:${DEPLOYER_VERSION}" --verbose
+
+      - name: "Cleanup verification resources"
+        if: always()
+        run: |
+          kubectl get ns -l app.kubernetes.io/name=apptest -o name | xargs -r kubectl delete --wait=false

--- a/.github/workflows/gke-verify.yaml
+++ b/.github/workflows/gke-verify.yaml
@@ -22,32 +22,32 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: "Authenticate to Google Cloud"
         id: "gcp-auth"
-        uses: google-github-actions/auth@62cf5bd3e4211a0a0b51f2c6d6a37129d828611d # v2.1.5
+        uses: google-github-actions/auth@v2 # v2.1.5
         with:
           workload_identity_provider: "projects/1053957112592/locations/global/workloadIdentityPools/github-actions-oidc-pool/providers/github-actions-oidc-provider"
           service_account: "github-actions-sa@prj-infra-automation-ktbz.iam.gserviceaccount.com"
           token_format: "access_token"
 
       - name: "Setup gcloud CLI"
-        uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7
+        uses: google-github-actions/setup-gcloud@v2
         with:
           install_components: 'kubectl'
 
       - name: "Docker login to Artifact Registry"
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@v3
         with:
           registry: us-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: "Connect to GKE Cluster"
-        uses: google-github-actions/get-gke-credentials@4d042ce21867b02551fee51e20bffc05689d8f94
+        uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: hg-dev-green
 
@@ -69,10 +69,10 @@ jobs:
           VERSION=$(cat VERSION)
           echo "TAG=${VERSION}" >> $GITHUB_ENV
           echo "DEPLOYER_VERSION=$(echo ${VERSION} | cut -d'.' -f 1-2)" >> $GITHUB_ENV
-          echo "REGISTRY=us-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway" >> $GITHUB_ENV
+          echo "REGISTRY=us-east4-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway" >> $GITHUB_ENV
 
       - name: "Build deployer image"
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v4.6.0
+        uses: docker/build-push-action@v5 # v4.6.0
         with:
           context: .
           file: dev.Dockerfile

--- a/.github/workflows/gke-verify.yaml
+++ b/.github/workflows/gke-verify.yaml
@@ -10,7 +10,8 @@ on:
       - 'schema.yaml'
       - 'dev.Dockerfile'
       - 'VERSION'
-
+  repository_dispatch:
+    types: [ verify-gateway ]
 permissions:
   contents: read
   id-token: write

--- a/gke-deploy.sh
+++ b/gke-deploy.sh
@@ -25,7 +25,7 @@ if [[ "${ENVIRONMENT:-}" = 'production' ]]; then
   export REGISTRY=gcr.io/virtru-public/gateway;
   printf 'Deploying to production. Using registry [%s]\n' $REGISTRY
 else
-  export REGISTRY=us-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway;
+  export REGISTRY=us-east4-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway;
   printf 'Deploying to development. Using registry [%s]\n' $REGISTRY
 fi
 

--- a/gke-deploy.sh
+++ b/gke-deploy.sh
@@ -25,7 +25,7 @@ if [[ "${ENVIRONMENT:-}" = 'production' ]]; then
   export REGISTRY=gcr.io/virtru-public/gateway;
   printf 'Deploying to production. Using registry [%s]\n' $REGISTRY
 else
-  export REGISTRY=gcr.io/prj-hosted-gateway-dev-qvec/gateway;
+  export REGISTRY=us-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway;
   printf 'Deploying to development. Using registry [%s]\n' $REGISTRY
 fi
 

--- a/gke-deploy.sh
+++ b/gke-deploy.sh
@@ -25,8 +25,8 @@ if [[ "${ENVIRONMENT:-}" = 'production' ]]; then
   export REGISTRY=gcr.io/virtru-public/gateway;
   printf 'Deploying to production. Using registry [%s]\n' $REGISTRY
 else
-  export REGISTRY=gcr.io/virtru-public/staging/gateway;
-  printf 'Deploying to staging. Using registry [%s]\n' $REGISTRY
+  export REGISTRY=gcr.io/prj-hosted-gateway-dev-qvec/gateway;
+  printf 'Deploying to development. Using registry [%s]\n' $REGISTRY
 fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/gke-verify.sh
+++ b/gke-verify.sh
@@ -22,7 +22,7 @@ if [[ "${ENVIRONMENT:-}" = 'production' ]]; then
   export REGISTRY=gcr.io/virtru-public/gateway;
   printf 'Deploying to production. Using registry [%s]\n' $REGISTRY
 else
-  export REGISTRY=gcr.io/prj-hosted-gateway-dev-qvec/gateway;
+  export REGISTRY=us-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway;
   printf 'Deploying to development. Using registry [%s]\n' $REGISTRY
 fi
 

--- a/gke-verify.sh
+++ b/gke-verify.sh
@@ -22,8 +22,8 @@ if [[ "${ENVIRONMENT:-}" = 'production' ]]; then
   export REGISTRY=gcr.io/virtru-public/gateway;
   printf 'Deploying to production. Using registry [%s]\n' $REGISTRY
 else
-  export REGISTRY=gcr.io/virtru-public/staging/gateway;
-  printf 'Deploying to staging. Using registry [%s]\n' $REGISTRY
+  export REGISTRY=gcr.io/prj-hosted-gateway-dev-qvec/gateway;
+  printf 'Deploying to development. Using registry [%s]\n' $REGISTRY
 fi
 
 printf 'Using container tag = [%s] and deployer version = [%s]\n' $TAG $DEPLOYER_VERSION
@@ -33,7 +33,7 @@ printf 'Using container tag = [%s] and deployer version = [%s]\n' $TAG $DEPLOYER
 # To make sure not to bill, use "gs://cloud-marketplace-tools/reporting_secrets/fake_reporting_secret.yaml"}'
 
 docker build --platform linux/amd64 --no-cache --build-arg TAG="${TAG}" --build-arg REGISTRY="${REGISTRY}" \
-  -t "${REGISTRY}/deployer:${DEPLOYER_VERSION}" -f dev.Dockerfile "${SCRIPT_DIR}" 
+  -t "${REGISTRY}/deployer:${DEPLOYER_VERSION}" -f dev.Dockerfile "${SCRIPT_DIR}"
 
 docker push "${REGISTRY}/deployer:${DEPLOYER_VERSION}"
 

--- a/gke-verify.sh
+++ b/gke-verify.sh
@@ -22,7 +22,7 @@ if [[ "${ENVIRONMENT:-}" = 'production' ]]; then
   export REGISTRY=gcr.io/virtru-public/gateway;
   printf 'Deploying to production. Using registry [%s]\n' $REGISTRY
 else
-  export REGISTRY=us-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway;
+  export REGISTRY=us-east4-docker.pkg.dev/prj-hosted-gateway-dev-qvec/gateway/gateway;
   printf 'Deploying to development. Using registry [%s]\n' $REGISTRY
 fi
 


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows for deploying and verifying the Gateway application on the development GKE cluster, and updates the registry URLs in deployment scripts to align with the development environment. 

* Added `.github/workflows/gke-deploy.yaml` to automate Gateway deployment to the development GKE cluster, including steps for authentication, building images, setting parameters, and verifying deployment status.
* Added `.github/workflows/gke-verify.yaml` to automate the verification of Gateway Marketplace deployments on the development cluster, including building images, running mpdev verification, and cleaning up resources.